### PR TITLE
Update g8 README's vertx-scala repo name

### DIFF
--- a/src/main/g8/README.md
+++ b/src/main/g8/README.md
@@ -41,7 +41,7 @@ sbt docker
 To run use
 
 ```
-docker run -p 8666:8666 default/vertx-scala-sbt
+docker run -p 8666:8666 default/vertx-scala
 ```
 
 Point your browser to [http://127.0.0.1:8666/hello](http://127.0.0.1:8666/hello) and enjoy :)


### PR DESCRIPTION
The docker image created is named `vertx-scala` instead of `vertx-scala-sbt` like the g8 README says.